### PR TITLE
a

### DIFF
--- a/HTML/proto/main-styles.css
+++ b/HTML/proto/main-styles.css
@@ -111,6 +111,7 @@
 		position: absolute;
 		top: 100%;
 		left: 0;		
+		width: 100%; 
 	}
 	
 	

--- a/HTML/proto/testside.html
+++ b/HTML/proto/testside.html
@@ -29,7 +29,7 @@
 					<div class="dropdown-Link">
 						<a href="#" class="menu-link">Produkter</a>							
 						<div class="dropdown-content">
-							<div class="dropdown-sub1" >
+							<div class="dropdown-sub1" style="display: block">
 								<a href="#">12 - 95kW</a>
 							</div>
 							<a href="#">145 - 360kW</a>


### PR DESCRIPTION
Angående forsvundet <div> på produktgruppe-mellemsider: Hvis den hvide
baggrund med links skal vises, så skal dens div ændres til display:
block, eller inline-block.

Linkfarver i mellemgrupper ændres i indstillinger->Site->kodefelt

Det er noget lettere at undlade at bruge tabeller i produktundergrupper
og bare bruge alm links <a>

Find ud af hvor det er bedst at placere de forskellige layout kode-klip,
enten i Site eller i skin. (skin bliver parset sidst af de to, så ofte
virker
det bedst at placere ændringerne her)

Få ryddet op i de forskellige kodefelter, især dubletter og ting der
ikke har effekt.